### PR TITLE
Add Linux Mint support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   tags: maven
   assert:
     that:
-      - ansible_os_family in ['Archlinux', 'Debian', 'RedHat', 'Suse']
+      - ansible_os_family in ['Archlinux', 'Debian', 'RedHat', 'Suse', 'Linuxmint']
 
 
 - name: Load version vars


### PR DESCRIPTION
Currently the role fails on Linux Mint (a distribution based on Ubuntu). This change makes the role recognise this distribution.
Tested on Linux Mint 17.1 (latest atm)