### PR TITLE
Don't require local root

### DIFF
--- a/tasks/local.yml
+++ b/tasks/local.yml
@@ -1,10 +1,9 @@
 ---
 - name: Install local ansible data path directory
   tags: maven
+  sudo: no
   local_action: file
     state=directory
-    owner=0
-    group=0
     mode=2777
     dest={{ local_ansible_data_path }}
 


### PR DESCRIPTION
Instead of requiring local root/passwordless sudo, use the current user to create the local data path directory.